### PR TITLE
quick-fixes

### DIFF
--- a/src/beam_postgres/client.py
+++ b/src/beam_postgres/client.py
@@ -160,5 +160,5 @@ def get_connection(config: Dict):
         raise PostgresConnectorError(
             f"Failed to connect postgres, Raise exception: {e}"
         )
-    finally:
+    else:
         conn.close()

--- a/src/beam_postgres/io.py
+++ b/src/beam_postgres/io.py
@@ -135,7 +135,7 @@ class _WriteToPostgresFn(beam.DoFn):
             ]
         )
 
-        query = f"INSERT INTO {self._config['database']}.{self._table}({column_str}) VALUES({value_str});"
+        query = f"INSERT INTO {self._table}({column_str}) VALUES({value_str});"
 
         self._queries.append(query)
 


### PR DESCRIPTION
Fixes:
- When creating the connection, we need to close it only if it was created.
- When writing rows, using the database in the query is not necessary and triggers an error if the database name contains dashes.